### PR TITLE
Time parameters must be submitted to Instagram as a valid unix timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .classpath
 .project
 .settings
+.gitignore
 *~
 target/
+bin/
+lib/

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -201,11 +201,11 @@ public class Instagram {
         }
 
         if(maxTimeStamp != null) {
-            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()));
+            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()/1000));
         }
 
         if(minTimeStamp != null) {
-            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()));
+            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()/1000));
         }
 
         String methodName = String.format(Methods.USERS_RECENT_MEDIA, userId);
@@ -452,11 +452,11 @@ public class Instagram {
         params.put(QueryParam.LONGITUDE, Double.toString(longitude));
 
         if(maxTimeStamp != null) {
-            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()));
+            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()/1000));
         }
 
         if(minTimeStamp != null) {
-            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()));
+            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()/1000));
         }
 
         params.put(QueryParam.DISTANCE, String.valueOf(distance));
@@ -682,11 +682,11 @@ public class Instagram {
         Map<String, String> params = new HashMap<String, String>();
 
         if(maxTimeStamp != null) {
-            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()));
+            params.put(QueryParam.MAX_TIMESTAMP, String.valueOf(maxTimeStamp.getTime()/1000));
         }
 
         if(minTimeStamp != null) {
-            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()));
+            params.put(QueryParam.MIN_TIMESTAMP, String.valueOf(minTimeStamp.getTime()/1000));
         }
 
         if(minId > 0)

--- a/src/test/java/org/jinstagram/integration/IntegrationTest.java
+++ b/src/test/java/org/jinstagram/integration/IntegrationTest.java
@@ -1,9 +1,10 @@
-package org.jinstagram;
+package org.jinstagram.integration;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Scanner;
 
+import org.jinstagram.Instagram;
 import org.jinstagram.auth.InstagramAuthService;
 import org.jinstagram.auth.model.Token;
 import org.jinstagram.auth.model.Verifier;


### PR DESCRIPTION
Send time parameter in seconds rather than Java Date.getTime milliseconds.
IntetgrationTest.java package name fixed, required Instagram class imported.
