### PR TITLE
Allow params in tags recent media

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -600,6 +600,22 @@ public class Instagram {
 	}
 
     /**
+     * Get a list of tagged media including params. This allows you to loop through all tags
+     * by passing a map with next_max_id from the previous request.
+     *
+     * @param tagName
+     * @param params
+     * @return
+     * @throws InstagramException
+     */
+    public TagMediaFeed getRecentMediaTags(String tagName, Map<String, String> params) throws InstagramException {
+        String apiMethod = String.format(Methods.TAGS_RECENT_MEDIA, tagName);
+        TagMediaFeed feed = createInstagramObject(Verbs.GET, TagMediaFeed.class, apiMethod, params);
+
+        return feed;
+    }
+
+    /**
      * Get a list of recently tagged media.
      *
      * @param tagName name of the tag.


### PR DESCRIPTION
This will allow the user to get all media that has this tag by sending in params map with next max id from the previous request.

Anyways, great work.. Really like your implementation of the instagram API!
