### PR TITLE
Add API to query the API call limit.

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -773,7 +773,7 @@ public class Instagram {
 	 * @return
 	 * @throws InstagramException
 	 */
-	private <T> T createInstagramObject(Verbs verbs, Class<T> clazz, String methodName, Map<String, String> params)
+	private <T extends InstagramObject> T createInstagramObject(Verbs verbs, Class<T> clazz, String methodName, Map<String, String> params)
         throws InstagramException {
             Response response;
             try {
@@ -784,7 +784,7 @@ public class Instagram {
 
             if (response.getCode() >= 200 && response.getCode() < 300) {
                 T object = createObjectFromResponse(clazz, response.getBody());
-
+                object.setHeaders(response.getHeaders());
                 return object;
             }
 

--- a/src/main/java/org/jinstagram/InstagramObject.java
+++ b/src/main/java/org/jinstagram/InstagramObject.java
@@ -1,0 +1,55 @@
+package org.jinstagram;
+
+import java.util.Map;
+
+import org.jinstagram.http.APILimitUtils;
+
+/**
+ * InstagramObject is a super abstract class that contains the HTTP headers from Response instance
+ * when we created an entity via Instagram.createInstagramObject.
+ * 
+ * @author Arinto Murdopo
+ *
+ */
+public abstract class InstagramObject {
+	
+	private Map<String, String> headers;
+	
+	/**
+	 * Package-private method so that Instagram can set HTTP headers
+	 * when creating the entity.
+	 * 
+	 * @param headers
+	 */
+	void setHeaders(Map<String, String> headers){
+		this.headers = headers;
+	}
+	
+	/**
+	 * Get the HTTP headers
+	 * @return HTTP headers from the respective Response instance
+	 */
+	public Map<String, String> getHeaders(){
+		return this.headers;
+	}
+	
+	/**
+	 * Get the available API limit. It correspond to the value of 
+	 * X-Ratelimit-Limit key in HTTP response headers. For Instagram 
+	 * v1 API, this method should return 5000.
+	 * @return Available API limit
+	 */
+	public int getAPILimitStatus(){
+		return APILimitUtils.getAPILimitStatus(this.headers);
+	}
+	
+	/**
+	 * Get the remaining API limit. It correspond to the value of 
+	 * X-Ratelimit-Remaining key in HTTP response headers.
+	 * @return Remaining API limit
+	 */
+	public int getRemainingLimitStatus(){
+		return APILimitUtils.getRemainingLimitStatus(this.headers);
+	}
+
+}

--- a/src/main/java/org/jinstagram/entity/comments/MediaCommentResponse.java
+++ b/src/main/java/org/jinstagram/entity/comments/MediaCommentResponse.java
@@ -2,9 +2,10 @@ package org.jinstagram.entity.comments;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 
-public class MediaCommentResponse {
+public class MediaCommentResponse extends InstagramObject{
 	@SerializedName("data")
 	private CommentData commentData;
 

--- a/src/main/java/org/jinstagram/entity/comments/MediaCommentsFeed.java
+++ b/src/main/java/org/jinstagram/entity/comments/MediaCommentsFeed.java
@@ -2,11 +2,12 @@ package org.jinstagram.entity.comments;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 
 import java.util.List;
 
-public class MediaCommentsFeed {
+public class MediaCommentsFeed extends InstagramObject{
 	@SerializedName("data")
 	private List<CommentData> commentDataList;
 

--- a/src/main/java/org/jinstagram/entity/likes/LikesFeed.java
+++ b/src/main/java/org/jinstagram/entity/likes/LikesFeed.java
@@ -2,12 +2,13 @@ package org.jinstagram.entity.likes;
 
 import java.util.List;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.common.User;
 
 import com.google.gson.annotations.SerializedName;
 
-public class LikesFeed {
+public class LikesFeed extends InstagramObject{
 
 	@SerializedName("meta")
 	private Meta meta;

--- a/src/main/java/org/jinstagram/entity/locations/LocationInfo.java
+++ b/src/main/java/org/jinstagram/entity/locations/LocationInfo.java
@@ -1,10 +1,11 @@
 package org.jinstagram.entity.locations;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Location;
 
 import com.google.gson.annotations.SerializedName;
 
-public class LocationInfo {
+public class LocationInfo extends InstagramObject{
 
 	@SerializedName("data")
 	private Location locationData;

--- a/src/main/java/org/jinstagram/entity/locations/LocationSearchFeed.java
+++ b/src/main/java/org/jinstagram/entity/locations/LocationSearchFeed.java
@@ -2,11 +2,12 @@ package org.jinstagram.entity.locations;
 
 import java.util.List;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Location;
 
 import com.google.gson.annotations.SerializedName;
 
-public class LocationSearchFeed {
+public class LocationSearchFeed extends InstagramObject{
 
 	@SerializedName("data")
 	private List<Location> locationList;

--- a/src/main/java/org/jinstagram/entity/media/MediaInfoFeed.java
+++ b/src/main/java/org/jinstagram/entity/media/MediaInfoFeed.java
@@ -2,10 +2,11 @@ package org.jinstagram.entity.media;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.users.feed.MediaFeedData;
 
-public class MediaInfoFeed {
+public class MediaInfoFeed extends InstagramObject{
 	@SerializedName("data")
 	private MediaFeedData data;
 

--- a/src/main/java/org/jinstagram/entity/relationships/RelationshipFeed.java
+++ b/src/main/java/org/jinstagram/entity/relationships/RelationshipFeed.java
@@ -2,9 +2,10 @@ package org.jinstagram.entity.relationships;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 
-public class RelationshipFeed {
+public class RelationshipFeed extends InstagramObject{
 	@SerializedName("data")
 	private RelationshipData data;
 

--- a/src/main/java/org/jinstagram/entity/tags/TagInfoFeed.java
+++ b/src/main/java/org/jinstagram/entity/tags/TagInfoFeed.java
@@ -2,9 +2,10 @@ package org.jinstagram.entity.tags;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 
-public class TagInfoFeed {
+public class TagInfoFeed extends InstagramObject{
 	@SerializedName("meta")
 	private Meta meta;
 

--- a/src/main/java/org/jinstagram/entity/tags/TagMediaFeed.java
+++ b/src/main/java/org/jinstagram/entity/tags/TagMediaFeed.java
@@ -2,13 +2,14 @@ package org.jinstagram.entity.tags;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.common.Pagination;
 import org.jinstagram.entity.users.feed.MediaFeedData;
 
 import java.util.List;
 
-public class TagMediaFeed {
+public class TagMediaFeed extends InstagramObject{
 	@SerializedName("data")
 	private List<MediaFeedData> data;
 

--- a/src/main/java/org/jinstagram/entity/tags/TagSearchFeed.java
+++ b/src/main/java/org/jinstagram/entity/tags/TagSearchFeed.java
@@ -2,11 +2,12 @@ package org.jinstagram.entity.tags;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 
 import java.util.List;
 
-public class TagSearchFeed {
+public class TagSearchFeed extends InstagramObject{
 	@SerializedName("meta")
 	private Meta meta;
 

--- a/src/main/java/org/jinstagram/entity/users/basicinfo/UserInfo.java
+++ b/src/main/java/org/jinstagram/entity/users/basicinfo/UserInfo.java
@@ -1,8 +1,10 @@
 package org.jinstagram.entity.users.basicinfo;
 
+import org.jinstagram.InstagramObject;
+
 import com.google.gson.annotations.SerializedName;
 
-public class UserInfo {
+public class UserInfo extends InstagramObject{
 	@SerializedName("data")
 	private UserInfoData data;
 

--- a/src/main/java/org/jinstagram/entity/users/feed/MediaFeed.java
+++ b/src/main/java/org/jinstagram/entity/users/feed/MediaFeed.java
@@ -2,12 +2,13 @@ package org.jinstagram.entity.users.feed;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.common.Pagination;
 
 import java.util.List;
 
-public class MediaFeed {
+public class MediaFeed extends InstagramObject{
 	@SerializedName("data")
 	private List<MediaFeedData> data;
 

--- a/src/main/java/org/jinstagram/entity/users/feed/UserFeed.java
+++ b/src/main/java/org/jinstagram/entity/users/feed/UserFeed.java
@@ -2,12 +2,13 @@ package org.jinstagram.entity.users.feed;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.common.Pagination;
 
 import java.util.List;
 
-public class UserFeed {
+public class UserFeed extends InstagramObject{
 	@SerializedName("meta")
 	private Meta meta;
 

--- a/src/main/java/org/jinstagram/http/APILimitUtils.java
+++ b/src/main/java/org/jinstagram/http/APILimitUtils.java
@@ -1,0 +1,50 @@
+package org.jinstagram.http;
+
+import java.util.Map;
+
+/**
+ * Helper class to process the HTTP headers from a Response object 
+ * and get the available and remaining API limit status
+ * @author Arinto Murdopo
+ *
+ */
+public class APILimitUtils {
+	
+	private static final String LIMIT_HEADER_KEY = "X-Ratelimit-Limit";
+	private static final String REMAINING_HEADER_KEY = "X-Ratelimit-Remaining";
+	
+	/**
+	 * Get the available API limit. It correspond to the value of 
+	 * X-Ratelimit-Limit key in HTTP response headers. For Instagram 
+	 * v1 API, this method should return 5000.
+	 * @param headers HTTP headers from a Response object
+	 * @return Available API limit
+	 */
+	public static int getAPILimitStatus(Map<String, String> headers){
+		return APILimitUtils.getIntegerValue(headers, LIMIT_HEADER_KEY);
+	}
+	
+	/**
+	 * Get the remaining API limit. It correspond to the value of 
+	 * X-Ratelimit-Remaining key in HTTP response headers.
+	 * @param headers HTTP headers from a Response object
+	 * @return Remaining API limit
+	 */
+	public static int getRemainingLimitStatus(Map<String, String> headers){
+		return APILimitUtils.getIntegerValue(headers, REMAINING_HEADER_KEY);
+	}
+	
+	private static int getIntegerValue(Map<String, String> header, String key){
+		String intValueStr = header.get(key);
+		int value = -1;
+		
+		try {
+			value = Integer.valueOf(intValueStr);
+		} catch (NumberFormatException e) {
+			System.out.printf("Invalid Integer value for key: %s, value %s%n", key, intValueStr);
+		}
+		return value;
+	}
+	
+
+}

--- a/src/test/java/org/jinstagram/entity/common/ImagesTest.java
+++ b/src/test/java/org/jinstagram/entity/common/ImagesTest.java
@@ -1,13 +1,12 @@
 package org.jinstagram.entity.common;
 
-import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
 
 public class ImagesTest {
     private Gson GSON_PARSER = new Gson();

--- a/src/test/java/org/jinstagram/entity/common/LocationTest.java
+++ b/src/test/java/org/jinstagram/entity/common/LocationTest.java
@@ -1,13 +1,12 @@
 package org.jinstagram.entity.common;
 
-import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
 
 public class LocationTest {
     private Gson GSON_PARSER = new Gson();

--- a/src/test/java/org/jinstagram/entity/common/VideoDataTest.java
+++ b/src/test/java/org/jinstagram/entity/common/VideoDataTest.java
@@ -1,13 +1,12 @@
 package org.jinstagram.entity.common;
 
-import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
 
 public class VideoDataTest {
     private Gson GSON_PARSER = new Gson();

--- a/src/test/java/org/jinstagram/integration/IntegrationTest.java
+++ b/src/test/java/org/jinstagram/integration/IntegrationTest.java
@@ -1,13 +1,10 @@
-package org.jinstagram;
+package org.jinstagram.integration;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Scanner;
 
-import org.jinstagram.auth.InstagramAuthService;
+import org.jinstagram.Instagram;
 import org.jinstagram.auth.model.Token;
-import org.jinstagram.auth.model.Verifier;
-import org.jinstagram.auth.oauth.InstagramService;
 import org.jinstagram.entity.users.basicinfo.UserInfo;
 import org.jinstagram.entity.users.feed.MediaFeed;
 import org.jinstagram.entity.users.feed.MediaFeedData;
@@ -16,7 +13,6 @@ import org.jinstagram.exceptions.InstagramException;
 
 public class IntegrationTest {
 
-    private static final Token EMPTY_TOKEN = null;
 
     public static void main(String[] args) throws InstagramException {
       /*


### PR DESCRIPTION
Add basic support to get the API limit as explained in issue #35. 

Summarized design:
1. Create abstract class `InstagramObject` which has methods to set `Response` and get the remaining limit and available limit.
2. All entities class that are created using `Instagram.CreateInstagramObject` extend from the new abstract class `InstagramObject` so that we can set the `Response` inside `InstagramObject`.
3. Client can query the limit after it creates the entities by calling `getRemainingLimitStatus` method. 
