### PR TITLE
Set Instagram methods to protected and return called URL in Response

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -791,7 +791,7 @@ public class Instagram {
             throw handleInstagramError(response);
         }
 
-    private InstagramException handleInstagramError(Response response) throws InstagramException {
+    protected InstagramException handleInstagramError(Response response) throws InstagramException {
         Gson gson = new Gson();
         final InstagramErrorResponse error;
         try {
@@ -819,7 +819,7 @@ public class Instagram {
 	 * @param params parameters which would be sent with the request.
 	 * @return Response object.
 	 */
-	private Response getApiResponse(Verbs verb, String methodName, Map<String, String> params) throws IOException {
+	protected Response getApiResponse(Verbs verb, String methodName, Map<String, String> params) throws IOException {
 		Response response;
 		String apiResourceUrl = config.getApiURL() + methodName;
 		OAuthRequest request = new OAuthRequest(verb, apiResourceUrl);
@@ -865,7 +865,7 @@ public class Instagram {
 	 * @return a object of type <T>
 	 * @throws InstagramException if any error occurs.
 	 */
-        private <T> T createObjectFromResponse(Class<T> clazz, final String response) throws InstagramException {
+        protected <T> T createObjectFromResponse(Class<T> clazz, final String response) throws InstagramException {
             Gson gson = new Gson();
             T object;
 

--- a/src/main/java/org/jinstagram/http/Response.java
+++ b/src/main/java/org/jinstagram/http/Response.java
@@ -22,11 +22,14 @@ public class Response {
 	private Map<String, String> headers;
 
 	private InputStream stream;
+	
+	private String url;
 
 	Response(HttpURLConnection connection) throws IOException {
 		try {
 			connection.connect();
 
+            url = connection.getURL().toString();
 			code = connection.getResponseCode();
 			headers = parseHeaders(connection);
 			stream = wasSuccessful() ? connection.getInputStream() : connection
@@ -36,6 +39,10 @@ public class Response {
 			code = 404;
 			body = EMPTY;
 		}
+	}
+	
+	public String getURL() {
+		return url;
 	}
 
 	private String parseBodyContents() {


### PR DESCRIPTION
Hi!

I have modified some Access Modifiers in the org.jinstagram.Instagram from private to protected since I need to override some of the behaviour. Some of them for mocking and testing.

I also include the Instagram URL called by org.jinstagram.http.Response as a class field for logging purposes. When using the library sometimes is useful to log the URLs called for debugging and monitoring.
