### PR TITLE
Restore Java6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/org/jinstagram/realtime/SubscriptionUtil.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionUtil.java
@@ -1,6 +1,6 @@
 package org.jinstagram.realtime;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
@@ -43,7 +43,7 @@ public class SubscriptionUtil {
     
     public static VerificationResult verifySubscriptionPostRequestSignature(String clientSecret, byte[] rawJsonData, String xHubSignature) throws InstagramException{
     	SecretKeySpec keySpec;
-		keySpec = new SecretKeySpec(clientSecret.getBytes(StandardCharsets.UTF_8), HMAC_SHA1);
+		keySpec = new SecretKeySpec(clientSecret.getBytes(Charset.forName("UTF-8")), HMAC_SHA1);
     	Mac mac;
     	
     	try {

--- a/src/test/java/org/jinstagram/realtime/SubscriptionUtilTest.java
+++ b/src/test/java/org/jinstagram/realtime/SubscriptionUtilTest.java
@@ -1,7 +1,7 @@
 package org.jinstagram.realtime;
 
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 import org.jinstagram.exceptions.InstagramException;
 import org.jinstagram.realtime.SubscriptionUtil.VerificationResult;
@@ -16,7 +16,8 @@ public class SubscriptionUtilTest {
 		String jsonResponse = "[{\"subscription_id\":\"1\",\"object\":\"user\",\"object_id\":\"1234\",\"changed_aspect\":\"media\",\"time\":1297286541},{\"subscription_id\":\"2\",\"object\":\"tag\",\"object_id\":\"nofilter\",\"changed_aspect\":\"media\",\"time\":1297286541}]";
 		String xHubSignature = "53a41d80a55a9265fc72633d432e22e6dc05fd64";
 		
-		VerificationResult result = SubscriptionUtil.verifySubscriptionPostRequestSignature(clientSecret, jsonResponse.getBytes(StandardCharsets.UTF_8), xHubSignature);
+		VerificationResult result = SubscriptionUtil.verifySubscriptionPostRequestSignature(clientSecret,
+              jsonResponse.getBytes(Charset.forName("UTF-8")), xHubSignature);
 		Assert.assertTrue(result.isSuccess());
 	}
 }


### PR DESCRIPTION
This commit restores Java6 compatibility as only one helper class is
used and can easily be replaced. This allows to use jInstagram in more
environments.
