### PR TITLE
Enhance user feed data

### DIFF
--- a/src/main/java/org/jinstagram/entity/users/feed/UserFeedData.java
+++ b/src/main/java/org/jinstagram/entity/users/feed/UserFeedData.java
@@ -54,6 +54,7 @@ public class UserFeedData {
 	/**
 	 * @return the firstName
 	 */
+	@Deprecated
 	public String getFirstName() {
 		return firstName;
 	}
@@ -61,6 +62,7 @@ public class UserFeedData {
 	/**
 	 * @param firstName the firstName to set
 	 */
+	@Deprecated
 	public void setFirstName(String firstName) {
 		this.firstName = firstName;
 	}
@@ -82,6 +84,7 @@ public class UserFeedData {
 	/**
 	 * @return the lastName
 	 */
+	@Deprecated
 	public String getLastName() {
 		return lastName;
 	}
@@ -89,6 +92,7 @@ public class UserFeedData {
 	/**
 	 * @param lastName the lastName to set
 	 */
+	@Deprecated
 	public void setLastName(String lastName) {
 		this.lastName = lastName;
 	}
@@ -141,7 +145,7 @@ public class UserFeedData {
 
     @Override
     public String toString() {
-        return String.format("UserFeedData [id=%s, profilePictureUrl=%s, userName=%s, website=%s, bio=%s]",
-                id, profilePictureUrl, userName, website, bio);
+        return String.format("UserFeedData [id=%s, profilePictureUrl=%s, userName=%s, fullName=%s, website=%s, bio=%s]",
+                id, profilePictureUrl, userName, fullName, website, bio);
     }
 }

--- a/src/test/java/org/jinstagram/entity/users/users/feed/UserFeedDataTest.java
+++ b/src/test/java/org/jinstagram/entity/users/users/feed/UserFeedDataTest.java
@@ -1,5 +1,41 @@
 package org.jinstagram.entity.users.users.feed;
 
+import static org.junit.Assert.*;
+
+import org.jinstagram.entity.users.feed.UserFeedData;
+import org.junit.Test;
+
 public class UserFeedDataTest {
+    
+    @Test
+    public void testToString() {
+        UserFeedData ufd = new UserFeedData();
+        
+        final String aBio = "a bio";
+        ufd.setBio(aBio);
+        
+        final String aFullName = "a full name";
+        ufd.setFullName(aFullName);
+        
+        final long anID = 12345L;
+        ufd.setId(anID);
+        
+        final String anUrl = "http://images.ak.instagram.com/profiles/profile_493845840_75sq_1384173674.jpg";
+        ufd.setProfilePictureUrl(anUrl);
+        
+        final String anUserName = "a_user_name";
+        ufd.setUserName(anUserName);
+        
+        final String aWebsite = "http://larc.smu.edu.sg";
+        ufd.setWebsite(aWebsite);
+
+        String expectedToString = String
+                .format("UserFeedData [id=%s, profilePictureUrl=%s, userName=%s, "
+                        + "fullName=%s, website=%s, "
+                        + "bio=%s]",
+                        anID, anUrl, anUserName, aFullName, aWebsite, aBio);
+        
+       assertTrue(ufd.toString().equals(expectedToString));
+    }
 
 }


### PR DESCRIPTION
User feed data has additional fields, that are `website` and `bio`. Here is a sample of resulting user feed data JSON from Instagram Relationship endpoint (obtained using curl)

```
{
  "data": [
    {
      "id": "55969444",
      "full_name": "Michelle Cheong",
      "profile_picture": "http://images.ak.instagram.com/profiles/profile_55969444_75sq_1384792859.jpg",
      "website": "",
      "bio": "I have a degree in food consumption and staring.",
      "username": "muahmysocks"
    }, ..... //other users
  ],
  "meta": {
    "code": 200
  },
  "pagination": {
    "next_cursor": "1389620495075",
    "next_url": "https://api.instagram.com/v1/users/711643571/followed-by?access_token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&cursor=1389620495075"
  }
}
```

Hence I add new bio and website fields into `UserFeedData` class and deprecate the unnecessary methods. 
I also add a simple unit test to check `UserFeedData` fields. 
