### PR TITLE
Fix parsing of error response

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -797,14 +797,14 @@ public class Instagram {
         final InstagramErrorResponse error;
         try {
             if (response.getCode() == 400) {
-                error = gson.fromJson(response.getBody(), InstagramErrorResponse.class);
+                error = InstagramErrorResponse.parse(gson, response.getBody());
                 error.setHeaders(response.getHeaders());
                 error.throwException();
             }
             //sending too many requests too quickly;
             //limited to 5000 requests per hour per access_token or client_id overall.  (according to spec)
             else if (response.getCode() == 503) {
-                error = gson.fromJson(response.getBody(), InstagramErrorResponse.class);
+                error = InstagramErrorResponse.parse(gson, response.getBody());
                 error.setHeaders(response.getHeaders());
                 error.throwException();
             }

--- a/src/main/java/org/jinstagram/InstagramOembed.java
+++ b/src/main/java/org/jinstagram/InstagramOembed.java
@@ -67,14 +67,8 @@ public class InstagramOembed {
     private InstagramException handleInstagramError(Response response) throws InstagramException {
         if (response.getCode() == 400) {
             Gson gson = new Gson();
-            final InstagramErrorResponse error;
-            try {
-                System.out.println(response.getBody());
-                error = gson.fromJson(response.getBody(), InstagramErrorResponse.class);
-                error.setHeaders(response.getHeaders());
-            } catch (JsonSyntaxException e) {
-                throw new InstagramException("Failed to decode error response " + response.getBody(), e, response.getHeaders());
-            }
+            final InstagramErrorResponse error = InstagramErrorResponse.parse(gson, response.getBody());
+            error.setHeaders(response.getHeaders());
             error.throwException();
         }
         throw new InstagramException("Unknown error response code: " + response.getCode() + " " + response.getBody(), response.getHeaders());


### PR DESCRIPTION
Prior to this commit, only json response containing a meta attribute
were parsed properly. Instagram can also send a response body that
is the content of the meta attribute itself.

This commit adds a method that parses both cases properly and
updated the tests to take that into account

Fixes gh-58
