### PR TITLE
Methods to get Instagram objects from the class InstagramService

### DIFF
--- a/src/main/java/org/jinstagram/auth/oauth/InstagramService.java
+++ b/src/main/java/org/jinstagram/auth/oauth/InstagramService.java
@@ -1,5 +1,6 @@
 package org.jinstagram.auth.oauth;
 
+import org.jinstagram.Instagram;
 import org.jinstagram.auth.InstagramApi;
 import org.jinstagram.auth.model.OAuthConfig;
 import org.jinstagram.auth.model.OAuthConstants;
@@ -89,5 +90,19 @@ public class InstagramService {
 	 */
 	public String getAuthorizationUrl(Token requestToken) {
 		return api.getAuthorizationUrl(config);
+	}
+
+	/**
+	 * Return an Instagram object
+	 */
+	public Instagram getInstagram(Token accessToken) {
+		return new Instagram(accessToken);
+	}
+
+	/**
+	 * Return an Instagram object with enforced signed header
+	 */
+	public Instagram getSignedHeaderInstagram(Token accessToken, String ipAddress) {
+		return new Instagram(accessToken.getToken(), config.getApiSecret(), ipAddress);
 	}
 }


### PR DESCRIPTION
Currently to get an `org.jinstagram.Instagram` object with enforce signed header we need to provide our api secret as an argument.
I would like this info to be stored only in our `org.jinstagram.auth.oauth.InstagramService` object and not in the class that creates the Instagram object.

A solution is to provide methods that directly returns the Instagram object. This way we don't need to store the secret anywhere else.