### PR TITLE
Better error handling in case of invalid JSON returned by Instagram API

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -940,24 +940,25 @@ public class Instagram {
 	protected InstagramException handleInstagramError(Response response) throws InstagramException {
 		Gson gson = new Gson();
 		final InstagramErrorResponse error;
+		String responseBody = response.getBody();
 		try {
 			if (response.getCode() == 400) {
-				error = InstagramErrorResponse.parse(gson, response.getBody());
+				error = InstagramErrorResponse.parse(gson, responseBody);
 				error.setHeaders(response.getHeaders());
 				error.throwException();
 			}
 			//sending too many requests too quickly;
 			//limited to 5000 requests per hour per access_token or client_id overall.  (according to spec)
 			else if (response.getCode() == 503) {
-				error = InstagramErrorResponse.parse(gson, response.getBody());
+				error = InstagramErrorResponse.parse(gson, responseBody);
 				error.setHeaders(response.getHeaders());
 				error.throwException();
 			}
 		} catch (JsonSyntaxException e) {
-			throw new InstagramException("Failed to decode error response " + response.getBody(), e,
+			throw new InstagramException("Failed to decode error response " + responseBody, e,
 					response.getHeaders());
 		}
-		throw new InstagramException("Unknown error response code: " + response.getCode() + " " + response.getBody(),
+		throw new InstagramException("Unknown error response code: " + response.getCode() + " " + responseBody,
 				response.getHeaders());
 	}
 


### PR DESCRIPTION
There are some Instagram APIs that doesn't handle well non-URL-encoded requests. For example, when I run the following request:

    curl -XGET "https://api.instagram.com/v1/tags/paixão/media/recent?access_token=ACCESS-TOKEN"

I get the following result body:

    <body><h1>400 Bad request</h1>
    Your browser sent an invalid request.
    </body></html>

The body returned is HTML, thus can't be parsed as JSON.

The method Instagram.handleInstagramError() should throw an InstagramException stating that it can't decode the error message.  But because the exception constructor is calling response.getBody() a second time, the following exception is being thrown:

    java.lang.IllegalStateException: Error while reading response body
            at org.jinstagram.http.StreamUtils.getStreamContents(StreamUtils.java:42)
            at org.jinstagram.http.Response.parseBodyContents(Response.java:47)
            at org.jinstagram.http.Response.getBody(Response.java:70)
            at org.jinstagram.Instagram.handleInstagramError(Instagram.java:957)
            at org.jinstagram.Instagram.createInstagramObject(Instagram.java:937)
            at org.jinstagram.Instagram.getRecentMediaTags(Instagram.java:735)
            at org.jinstagram.Instagram.getRecentMediaTags(Instagram.java:693)
            at org.jinstagram.Instagram.getRecentMediaTags(Instagram.java:681)
            at org.jinstagram.InstagramTest.testGetRecentMediaTags(InstagramTest.java:185)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:606)
            at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
            at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
            at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
            at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
            at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
            at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
            at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
            at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
            at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
            at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
            at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
            at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
            at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
            at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:606)
            at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
            at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
            at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
            at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
            at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
    Caused by: java.io.IOException: stream is closed
            at sun.net.www.http.ChunkedInputStream.ensureOpen(ChunkedInputStream.java:174)
            at sun.net.www.http.ChunkedInputStream.read(ChunkedInputStream.java:673)
            at java.io.FilterInputStream.read(FilterInputStream.java:133)
            at sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3052)
            at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:283)
            at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:325)
            at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:177)
            at java.io.InputStreamReader.read(InputStreamReader.java:184)
            at org.jinstagram.http.StreamUtils.getStreamContents(StreamUtils.java:31)
            ... 37 more

This PR solves this by reading the request body into a temporary variable and using it in all places that it is needed within the handleInstagramError method.