### PR TITLE
Managing deprecation of three api requests. Issue #130

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -193,7 +193,7 @@ public class Instagram {
      * through the review process.
      * See changelog on Nov 17, 2015
      *
-     * use getUsersRecentMedia() instead
+     * use getUserRecentMedia() instead
 	 */
     @Deprecated
 	public MediaFeed getUserFeeds() throws InstagramException {
@@ -209,8 +209,8 @@ public class Instagram {
      * @throws InstagramException
      * @author tolstovdmit
      */
-    public MediaFeed getUsersRecentMedia() throws InstagramException{
-        LogHelper.logEntrance(logger, "getUsersRecentMedia", null);
+    public MediaFeed getUserRecentMedia() throws InstagramException{
+        LogHelper.logEntrance(logger, "getUserRecentMedia", null);
         logger.info("Getting current user recent media...");
 
         return createInstagramObject(Verbs.GET, MediaFeed.class, Methods.USERS_SELF_RECENT_MEDIA, null);
@@ -227,8 +227,8 @@ public class Instagram {
      * @throws InstagramException
      * @author tolstovdmit
      */
-    public MediaFeed getUsersRecentMedia(int count, String minId, String maxId) throws InstagramException {
-        LogHelper.logEntrance(logger, "getUsersRecentMedia", "[ count : " + count + ", minId : " + minId + ", maxId : " + maxId + "]");
+    public MediaFeed getUserRecentMedia(int count, String minId, String maxId) throws InstagramException {
+        LogHelper.logEntrance(logger, "getUserRecentMedia", "[ count : " + count + ", minId : " + minId + ", maxId : " + maxId + "]");
         logger.info("Getting current user recent media...");
 
         Map<String, String> params = new HashMap<String, String>();
@@ -263,7 +263,7 @@ public class Instagram {
     * through the review process.
     * See changelog on Nov 17, 2015
     *
-    * use getUsersRecentMedia(int count, String minId, String maxId) instead
+    * use getUserRecentMedia(int count, String minId, String maxId) instead
 	*/
     @Deprecated
 	public MediaFeed getUserFeeds(String maxId, String minId, long count) throws InstagramException {

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -192,6 +192,8 @@ public class Instagram {
      * be moved to Sandbox Mode if it wasn't approved
      * through the review process.
      * See changelog on Nov 17, 2015
+     *
+     * use getUsersRecentMedia() instead
 	 */
     @Deprecated
 	public MediaFeed getUserFeeds() throws InstagramException {
@@ -260,6 +262,8 @@ public class Instagram {
     * be moved to Sandbox Mode if it wasn't approved
     * through the review process.
     * See changelog on Nov 17, 2015
+    *
+    * use getUsersRecentMedia(int count, String minId, String maxId) instead
 	*/
     @Deprecated
 	public MediaFeed getUserFeeds(String maxId, String minId, long count) throws InstagramException {

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -627,6 +627,8 @@ public class Instagram {
      * be moved to Sandbox Mode if it wasn't approved
      * through the review process.
      * See changelog on Nov 17, 2015
+     *
+     * No analog method was offered instead.
 	 */
     @Deprecated
 	public MediaFeed getPopularMedia() throws InstagramException {

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -202,6 +202,20 @@ public class Instagram {
         return createInstagramObject(Verbs.GET, MediaFeed.class, Methods.USERS_SELF_FEED, null);
     }
 
+    /**
+     * Get current user's recent media
+     *
+     * @return a MediaFeedObject
+     * @throws InstagramException
+     * @author tolstovdmit
+     */
+    public MediaFeed getUsersRecentMedia() throws InstagramException{
+        LogHelper.logEntrance(logger, "getUsersRecentMedia", null);
+        logger.info("Getting current user recent media...");
+
+        return createInstagramObject(Verbs.GET, MediaFeed.class, Methods.USERS_SELF_RECENT_MEDIA, null);
+    }
+
 	/**
 	* See the authenticated user's feed
 	*

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -2,9 +2,7 @@ package org.jinstagram;
 
 import java.io.IOException;
 import java.net.Proxy;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
@@ -214,6 +212,38 @@ public class Instagram {
         logger.info("Getting current user recent media...");
 
         return createInstagramObject(Verbs.GET, MediaFeed.class, Methods.USERS_SELF_RECENT_MEDIA, null);
+    }
+
+    /**
+     * Get current user's recent media with parameters.
+     *
+     *
+     * @param count Count of media to return.
+     * @param minId
+     * @param maxId
+     * @return a MediaFeedObject
+     * @throws InstagramException
+     * @author tolstovdmit
+     */
+    public MediaFeed getUsersRecentMedia(int count, String minId, String maxId) throws InstagramException {
+        LogHelper.logEntrance(logger, "getUsersRecentMedia", "[ count : " + count + ", minId : " + minId + ", maxId : " + maxId + "]");
+        logger.info("Getting current user recent media...");
+
+        Map<String, String> params = new HashMap<String, String>();
+
+        if (maxId != null) {
+            params.put(QueryParam.MAX_ID, String.valueOf(maxId));
+        }
+
+        if (minId != null) {
+            params.put(QueryParam.MIN_ID, String.valueOf(minId));
+        }
+
+        if (count != 0) {
+            params.put(QueryParam.COUNT, String.valueOf(count));
+        }
+
+        return createInstagramObject(Verbs.GET, MediaFeed.class, Methods.USERS_SELF_RECENT_MEDIA, params);
     }
 
 	/**

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -188,7 +188,14 @@ public class Instagram {
 	 *
 	 * @return a MediaFeed object.
 	 * @throws InstagramException if any error occurs.
+     * @deprecated Any app created before Nov 17, 2015
+     * will continue to function until June 2016.
+     * After June 2016, the app will automatically
+     * be moved to Sandbox Mode if it wasn't approved
+     * through the review process.
+     * See changelog on Nov 17, 2015
 	 */
+    @Deprecated
 	public MediaFeed getUserFeeds() throws InstagramException {
         LogHelper.logEntrance(logger, "getUserFeeds", null);
 
@@ -203,7 +210,14 @@ public class Instagram {
 	* @param count Count of media to return.
 	* @return a MediaFeed object.
 	* @throws InstagramException if any error occurs.
+    * @deprecated Any app created before Nov 17, 2015
+    * will continue to function until June 2016.
+    * After June 2016, the app will automatically
+    * be moved to Sandbox Mode if it wasn't approved
+    * through the review process.
+    * See changelog on Nov 17, 2015
 	*/
+    @Deprecated
 	public MediaFeed getUserFeeds(String maxId, String minId, long count) throws InstagramException {
         LogHelper.logEntrance(logger, "getUserFeeds", "[ maxId : " + maxId + ", minId : " + minId + ", count : " + count + "]");
 
@@ -593,7 +607,14 @@ public class Instagram {
 	 *
 	 * @return a MediaFeed object.
 	 * @throws InstagramException if any error occurs.
+     * @deprecated Any app created before Nov 17, 2015
+     * will continue to function until June 2016.
+     * After June 2016, the app will automatically
+     * be moved to Sandbox Mode if it wasn't approved
+     * through the review process.
+     * See changelog on Nov 17, 2015
 	 */
+    @Deprecated
 	public MediaFeed getPopularMedia() throws InstagramException {
 		MediaFeed mediaFeed = createInstagramObject(Verbs.GET, MediaFeed.class, Methods.MEDIA_POPULAR, null);
 

--- a/src/main/java/org/jinstagram/model/Methods.java
+++ b/src/main/java/org/jinstagram/model/Methods.java
@@ -133,6 +133,11 @@ public final class Methods {
     @Deprecated
 	public static final String USERS_SELF_FEED = "/users/self/feed";
 
+    /*
+     * Get the most recent media published by the owner of the access_token.
+     */
+    public static final String USERS_SELF_RECENT_MEDIA = "/users/self/media/recent";
+
 	/**
 	 * See the authenticated user's list of media they've liked. Note that this
 	 * list is ordered by the order in which the user liked the media. Private

--- a/src/main/java/org/jinstagram/model/Methods.java
+++ b/src/main/java/org/jinstagram/model/Methods.java
@@ -17,6 +17,7 @@ public final class Methods {
 	 * Note: you can only access Geographies that were explicitly created by
 	 * your OAuth client.
 	 */
+    @Deprecated
 	public static final String GEOGRAPHIES_RECENT_MEDIA_BY_ID = "/geographies/%s/media/recent";
 
 	/**
@@ -61,6 +62,7 @@ public final class Methods {
 	/**
 	 * Get a list of what media is most popular at the moment.
 	 */
+    @Deprecated
 	public static final String MEDIA_POPULAR = "/media/popular";
 
 	/**
@@ -128,6 +130,7 @@ public final class Methods {
 	/**
 	 * See the authenticated user's feed.
 	 */
+    @Deprecated
 	public static final String USERS_SELF_FEED = "/users/self/feed";
 
 	/**

--- a/src/main/java/org/jinstagram/realtime/InstagramSubscription.java
+++ b/src/main/java/org/jinstagram/realtime/InstagramSubscription.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public class InstagramSubscription {
 
 	private final Map<String, String> params;

--- a/src/main/java/org/jinstagram/realtime/SubscriptionResponse.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionResponse.java
@@ -4,6 +4,7 @@ import org.jinstagram.entity.common.Meta;
 
 import com.google.gson.annotations.SerializedName;
 
+@Deprecated
 public class SubscriptionResponse {
 
 	@SerializedName("meta")

--- a/src/main/java/org/jinstagram/realtime/SubscriptionResponseData.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionResponseData.java
@@ -2,6 +2,7 @@ package org.jinstagram.realtime;
 
 import com.google.gson.annotations.SerializedName;
 
+@Deprecated
 public class SubscriptionResponseData {
 
 	@SerializedName("object")

--- a/src/main/java/org/jinstagram/realtime/SubscriptionResponseObject.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionResponseObject.java
@@ -2,6 +2,7 @@ package org.jinstagram.realtime;
 
 import com.google.gson.annotations.SerializedName;
 
+@Deprecated
 public class SubscriptionResponseObject {
 
 	@SerializedName("changed_aspect")

--- a/src/main/java/org/jinstagram/realtime/SubscriptionType.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionType.java
@@ -1,5 +1,6 @@
 package org.jinstagram.realtime;
 
+@Deprecated
 public enum SubscriptionType {
 	/**
 	 * A enum to denote the 'user' subscription type.

--- a/src/main/java/org/jinstagram/realtime/SubscriptionUtil.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionUtil.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import org.apache.commons.codec.binary.Hex;
 import org.jinstagram.exceptions.InstagramException;
 
+@Deprecated
 public class SubscriptionUtil {
 
 	private static final String HMAC_SHA1 = "HmacSHA1";

--- a/src/main/java/org/jinstagram/realtime/SubscriptionsListResponse.java
+++ b/src/main/java/org/jinstagram/realtime/SubscriptionsListResponse.java
@@ -6,6 +6,7 @@ import org.jinstagram.entity.common.Meta;
 
 import com.google.gson.annotations.SerializedName;
 
+@Deprecated
 public class SubscriptionsListResponse {
 
     @SerializedName("meta")

--- a/src/test/java/org/jinstagram/InstagramTest.java
+++ b/src/test/java/org/jinstagram/InstagramTest.java
@@ -249,8 +249,8 @@ public class InstagramTest {
     }
 
     @Test
-    public void testGetUsersRecentMedia() throws Exception{
-        MediaFeed mf = instagram.getUsersRecentMedia();
+    public void testGetUserRecentMedia() throws Exception{
+        MediaFeed mf = instagram.getUserRecentMedia();
 
         List<MediaFeedData> mediaFeedDataList = mf.getData();
 
@@ -259,9 +259,9 @@ public class InstagramTest {
     }
 
     @Test
-    public void testGetUsersRecentMediaWithParams() throws  Exception{
+    public void testGetUserRecentMediaWithParams() throws  Exception{
 
-        MediaFeed mf = instagram.getUsersRecentMedia(2, null, null);
+        MediaFeed mf = instagram.getUserRecentMedia(2, null, null);
 
         List<MediaFeedData> mediaFeedDataList = mf.getData();
         Assert.assertEquals(mediaFeedDataList.size(), 2);

--- a/src/test/java/org/jinstagram/InstagramTest.java
+++ b/src/test/java/org/jinstagram/InstagramTest.java
@@ -15,6 +15,7 @@ import org.jinstagram.entity.users.feed.UserFeedData;
 import org.jinstagram.exceptions.InstagramBadRequestException;
 import org.jinstagram.exceptions.InstagramException;
 import org.jinstagram.exceptions.InstagramRateLimitException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -80,6 +81,7 @@ public class InstagramTest {
 
 
     @Test
+    @Ignore //cause getPopularMedia is deprecated
     public void testPopularMedia() throws Exception {
 
         logger.info("Printing a list of popular media...");
@@ -244,5 +246,27 @@ public class InstagramTest {
         meta.setErrorType("type");
 
         return new Gson().toJson(meta);
+    }
+
+    @Test
+    public void testGetUsersRecentMedia() throws Exception{
+        MediaFeed mf = instagram.getUsersRecentMedia();
+
+        List<MediaFeedData> mediaFeedDataList = mf.getData();
+
+        printMediaFeedList(mediaFeedDataList);
+
+    }
+
+    @Test
+    public void testGetUsersRecentMediaWithParams() throws  Exception{
+
+        MediaFeed mf = instagram.getUsersRecentMedia(2, null, null);
+
+        List<MediaFeedData> mediaFeedDataList = mf.getData();
+        Assert.assertEquals(mediaFeedDataList.size(), 2);
+
+        printMediaFeedList(mediaFeedDataList);
+
     }
 }

--- a/src/test/java/org/jinstagram/realtime/SubscriptionUtilTest.java
+++ b/src/test/java/org/jinstagram/realtime/SubscriptionUtilTest.java
@@ -3,6 +3,7 @@ package org.jinstagram.realtime;
 
 import java.nio.charset.Charset;
 
+import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.jinstagram.exceptions.InstagramException;
 import org.jinstagram.realtime.SubscriptionUtil.VerificationResult;
 import org.junit.Assert;
@@ -11,6 +12,7 @@ import org.junit.Test;
 public class SubscriptionUtilTest {
 	
 	@Test
+    @Ignore
 	public void shouldReturnSameResultWithPyhtonImplementation() throws InstagramException{
 		String clientSecret = "5f395ee5acae448bbbcf01a251c480f6";
 		String jsonResponse = "[{\"subscription_id\":\"1\",\"object\":\"user\",\"object_id\":\"1234\",\"changed_aspect\":\"media\",\"time\":1297286541},{\"subscription_id\":\"2\",\"object\":\"tag\",\"object_id\":\"nofilter\",\"changed_aspect\":\"media\",\"time\":1297286541}]";


### PR DESCRIPTION
Closing issue #130. Still need to deprecate

See: https://www.instagram.com/developer/changelog/ on Nov 17, 2015.
* Deprecation of /users/self/feed
* Deprecation of /media/popular
* Deprecation of /geographies/media/recent
* Deprecation of Realtime subscriptions for tags, locations and geographies

Added deprecated annotation and tags on methods using deprecated api.
Added deprecated annotations on classes of realtime package.
Added getUsersRecentMedia methods to replace getUserFeeds.
