### PR TITLE
Failing secure requests

### DIFF
--- a/src/main/java/org/jinstagram/model/Methods.java
+++ b/src/main/java/org/jinstagram/model/Methods.java
@@ -25,7 +25,7 @@ public final class Methods {
 	 *
 	 * Required scope : likes
 	 */
-	public static final String LIKES_BY_MEDIA_ID = "/media/%s/likes/";
+	public static final String LIKES_BY_MEDIA_ID = "/media/%s/likes";
 
 	/**
 	 * Get information about a location.
@@ -35,7 +35,7 @@ public final class Methods {
 	/**
 	 * Get a list of recent media objects from a given location.
 	 */
-	public static final String LOCATIONS_RECENT_MEDIA_BY_ID = "/locations/%s/media/recent/";
+	public static final String LOCATIONS_RECENT_MEDIA_BY_ID = "/locations/%s/media/recent";
 
 	/**
 	 * Search for a location by geographic coordinate.


### PR DESCRIPTION
I've found two endpoints which fail the signature validation: https://www.instagram.com/developer/secure-api-requests/

Both endpoints fail due to a trailing slash, which Instagram must remove on their end as part of the signature validation. Removing the slash allows the endpoints to pass signature validation, which is what this PR does.
