### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/jinstagram/entity/common/VideoData.java
+++ b/src/main/java/org/jinstagram/entity/common/VideoData.java
@@ -3,7 +3,16 @@ package org.jinstagram.entity.common;
 import com.google.gson.annotations.SerializedName;
 
 public class VideoData {
-
+	
+	@SerializedName("url")
+	private String url;
+	
+	@SerializedName("width")
+	private int width;
+	
+	@SerializedName("height")
+	private int height;
+	
 	public String getUrl() {
 		return url;
 	}
@@ -28,15 +37,6 @@ public class VideoData {
 		this.height = height;
 	}
 
-	@SerializedName("url")
-	private String url;
-
-	@SerializedName("width")
-	private int width;
-
-	@SerializedName("height")
-	private int height;
-	
     @Override
     public String toString() {
         return String.format("VideoData [videoWidth=%d, videoHeight=%d, videoUrl=%s]",

--- a/src/main/java/org/jinstagram/utils/LogHelper.java
+++ b/src/main/java/org/jinstagram/utils/LogHelper.java
@@ -7,6 +7,29 @@ import com.google.gson.JsonParser;
 import org.slf4j.Logger;
 
 public final class LogHelper {
+    
+    /**
+     * <p>
+     * The message format pattern used to log the exception.
+     * </p>
+     */
+    private static final String EXCEPTION_PATTERN = "Error in method {0}.\n\tException name: {1}.\n\t"
+            + "Stack trace: {2}.\n\tTime spent in the method: {3} milliseconds.";
+    
+    /**
+     * <p>
+     * The message format pattern used to log the exit of method.
+     * </p>
+     */
+    private static final String EXIT_METHOD_PATTERN = "Exiting method %s.\n\tReturn value: [{%s}].\n\tTime spent in the method: {2" +
+            "%d} milliseconds.";
+    
+    /**
+     * <p>
+     * The message format pattern used to log the entrance of method.
+     * </p>
+     */
+    private static final String ENTRANCE_METHOD_PATTERN = "Entering method %s.\n\tMethod arguments: [%s].";
 
     private static Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
@@ -18,29 +41,6 @@ public final class LogHelper {
      */
     private LogHelper() {
     }
-
-    /**
-     * <p>
-     * The message format pattern used to log the entrance of method.
-     * </p>
-     */
-    private static final String ENTRANCE_METHOD_PATTERN = "Entering method %s.\n\tMethod arguments: [%s].";
-
-    /**
-     * <p>
-     * The message format pattern used to log the exit of method.
-     * </p>
-     */
-    private static final String EXIT_METHOD_PATTERN = "Exiting method %s.\n\tReturn value: [{%s}].\n\tTime spent in the method: {2" +
-            "%d} milliseconds.";
-
-    /**
-     * <p>
-     * The message format pattern used to log the exception.
-     * </p>
-     */
-    private static final String EXCEPTION_PATTERN = "Error in method {0}.\n\tException name: {1}.\n\t"
-            + "Stack trace: {2}.\n\tTime spent in the method: {3} milliseconds.";
 
     /**
      * <p>


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava