### PR TITLE
squid:S2259 - Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -1141,9 +1141,9 @@ public class Instagram {
 		// check if we are enforcing a signed request and add the 'sig' parameter
 		if (config.isEnforceSignedRequest()) {
 			if ((verb == Verbs.GET) || (verb == Verbs.DELETE)) {
-				request.addQuerystringParameter(QueryParam.SIGNATURE, EnforceSignedRequestUtils.signature(methodName, request.getQueryStringParams(), accessToken.getSecret()));
+				request.addQuerystringParameter(QueryParam.SIGNATURE, EnforceSignedRequestUtils.signature(methodName, request.getQueryStringParams(), accessToken != null ? accessToken.getSecret() : null));
 			} else {
-				request.addBodyParameter(QueryParam.SIGNATURE, EnforceSignedRequestUtils.signature(methodName, request.getBodyParams(), accessToken.getSecret()));
+				request.addBodyParameter(QueryParam.SIGNATURE, EnforceSignedRequestUtils.signature(methodName, request.getBodyParams(), accessToken != null ? accessToken.getSecret() : null));
 			}
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2259 - Null pointers should not be dereferenced.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2259
Please let me know if you have any questions.
George Kankava