### PR TITLE
errorType getter

### DIFF
--- a/src/main/java/org/jinstagram/exceptions/InstagramException.java
+++ b/src/main/java/org/jinstagram/exceptions/InstagramException.java
@@ -75,7 +75,11 @@ public class InstagramException extends IOException implements InstagramResponse
         this.errorType = null;
     }
 
-	@Override
+    public String getErrorType() {
+        return errorType;
+    }
+
+    @Override
 	public int getAPILimitStatus() {
 		if (headers == null) {
 			return -1;

--- a/src/test/java/org/jinstagram/exceptions/InstagramExceptionTest.java
+++ b/src/test/java/org/jinstagram/exceptions/InstagramExceptionTest.java
@@ -136,4 +136,22 @@ public class InstagramExceptionTest {
 		assertEquals(-1, result);
 	}
 
+	/**
+	 * Run the int getErrorType() method test.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void testGetErrorType() throws Exception {
+		InstagramException fixture = new InstagramException(
+			"APINotAllowedError",
+			"APINotAllowedError: you cannot view this resource",
+			(Map<String, String>) null
+		);
+
+		assertEquals("APINotAllowedError", fixture.getErrorType());
+		assertEquals("APINotAllowedError: you cannot view this resource", fixture.getMessage());
+	}
+
 }


### PR DESCRIPTION
It appeared there is no way to get errorType from an exception rather then parse it from a message. It will be very handy for smart handling of different types of errors like `APINotAllowedError `.