### PR TITLE
check for a lower case header

### DIFF
--- a/src/main/java/org/jinstagram/http/APILimitUtils.java
+++ b/src/main/java/org/jinstagram/http/APILimitUtils.java
@@ -46,6 +46,9 @@ public final class APILimitUtils {
 
     private static int getIntegerValue(Map<String, String> header, String key) {
         String intValueStr = header.get(key);
+        if (intValueStr == null) {
+            intValueStr = header.get(key.toLowerCase());
+        }
         int value = -1;
 
         try {

--- a/src/test/java/org/jinstagram/http/APILimitUtilsTest.java
+++ b/src/test/java/org/jinstagram/http/APILimitUtilsTest.java
@@ -56,4 +56,17 @@ public class APILimitUtilsTest {
         assertTrue(defaultErrorValue == APILimitUtils.getAPILimitStatus(headers));
         assertTrue(defaultErrorValue == APILimitUtils.getRemainingLimitStatus(headers)); 
     }
+
+    @Test
+    public void lowerCase() {
+        int limitValue = 5000;
+        int remainingValue = 3999;
+
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put(APILimitUtils.LIMIT_HEADER_KEY.toLowerCase(), String.valueOf(limitValue));
+        headers.put(APILimitUtils.REMAINING_HEADER_KEY.toLowerCase(), String.valueOf(remainingValue));
+
+        assertTrue(limitValue == APILimitUtils.getAPILimitStatus(headers));
+        assertTrue(remainingValue == APILimitUtils.getRemainingLimitStatus(headers));
+    }
 }


### PR DESCRIPTION
It appeared Instagram responses contain headers in lower case. Added some logic to check for a lower case header if an original one wasn't found.