### PR TITLE
Handle URI-encoded tags when signing requests

### DIFF
--- a/src/main/java/org/jinstagram/http/URLUtils.java
+++ b/src/main/java/org/jinstagram/http/URLUtils.java
@@ -77,6 +77,31 @@ public class URLUtils {
     }
 
     /**
+     * Decodes the passed-in String as UTF-8 using an algorithm that's compatible
+     * with JavaScript's <code>decodeURIComponent</code> function. Returns
+     * <code>null</code> if the String is <code>null</code>.
+     *
+     * @param s The String to be decoded
+     * @return the decoded String
+     *
+     * (from: http://stackoverflow.com/questions/607176/java-equivalent-to-javascripts-encodeuricomponent-that-produces-identical-outpu)
+     */
+    public static  String decodeURIComponent(String s) {
+        String result = null;
+
+        try {
+          result = URLDecoder.decode(s, "UTF-8");
+        }
+
+        // This exception should never occur.
+        catch (UnsupportedEncodingException e) {
+          result = s;
+        }
+
+        return result;
+    }
+
+    /**
      * Turns a map into a form-urlencoded string
      * 
      * @param map any map

--- a/src/main/java/org/jinstagram/utils/PaginationHelper.java
+++ b/src/main/java/org/jinstagram/utils/PaginationHelper.java
@@ -46,6 +46,9 @@ public class PaginationHelper {
             return methodName;
         }
 
+        public String getRawMethodName() {
+            return URLUtils.decodeURIComponent(methodName);
+        }
         public Map<String, String> getQueryStringParams() {
             return queryStringParams;
         }


### PR DESCRIPTION
Hashtags with characters that require URI encoding (e.g. #señor) need to be signed un-encoded.

Credit to Gagan Jain @ Sprinklr for the original fix.

Fixes #168 