### PR TITLE
Correction on Scope authorization url and overload getRecentMediaByLocation

### DIFF
--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -1038,6 +1038,9 @@ public class Instagram {
      * @return a MediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * 
+     * @Deprecated recent media by location request with maxTimeStamp and minTimeStamp parameters was deprecated by instagram
+     *              
      */
     @Deprecated
     public MediaFeed getRecentMediaByLocation(String locationId, String minId, String maxId, Date maxTimeStamp,

--- a/src/main/java/org/jinstagram/Instagram.java
+++ b/src/main/java/org/jinstagram/Instagram.java
@@ -33,7 +33,11 @@ import org.jinstagram.http.Verbs;
 import org.jinstagram.model.Methods;
 import org.jinstagram.model.QueryParam;
 import org.jinstagram.model.Relationship;
-import org.jinstagram.utils.*;
+import org.jinstagram.utils.EnforceSignedHeaderUtils;
+import org.jinstagram.utils.EnforceSignedRequestUtils;
+import org.jinstagram.utils.LogHelper;
+import org.jinstagram.utils.PaginationHelper;
+import org.jinstagram.utils.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1010,6 +1014,23 @@ public class Instagram {
      *            Return media before this min_id. May be null.
      * @param maxId
      *            Return media before this max_id. May be null.
+     * @return a MediaFeed object.
+     * @throws InstagramException
+     *             if any error occurs.
+     */
+    public MediaFeed getRecentMediaByLocation(String locationId, String minId, String maxId) throws InstagramException {
+    	return getRecentMediaByLocation(locationId, minId, maxId, null, null);
+    }
+
+    /**
+     * Get a list of recent media objects from a given location.
+     *
+     * @param locationId
+     *            a id of the Media.
+     * @param minId
+     *            Return media before this min_id. May be null.
+     * @param maxId
+     *            Return media before this max_id. May be null.
      * @param maxTimeStamp
      *            Return media before this max date. May be null.
      * @param minTimeStamp
@@ -1018,6 +1039,7 @@ public class Instagram {
      * @throws InstagramException
      *             if any error occurs.
      */
+    @Deprecated
     public MediaFeed getRecentMediaByLocation(String locationId, String minId, String maxId, Date maxTimeStamp,
             Date minTimeStamp) throws InstagramException {
         Map<String, String> params = new HashMap<String, String>();

--- a/src/main/java/org/jinstagram/auth/InstagramApi.java
+++ b/src/main/java/org/jinstagram/auth/InstagramApi.java
@@ -1,8 +1,7 @@
 package org.jinstagram.auth;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
+import static org.jinstagram.http.URLUtils.formURLEncode;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jinstagram.auth.exceptions.OAuthException;
 import org.jinstagram.auth.model.Constants;
@@ -12,10 +11,9 @@ import org.jinstagram.auth.oauth.InstagramService;
 import org.jinstagram.http.Verbs;
 import org.jinstagram.utils.Preconditions;
 
-import static org.jinstagram.http.URLUtils.formURLEncode;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 
 public class InstagramApi {
 	public String getAccessTokenEndpoint() {
@@ -33,7 +31,7 @@ public class InstagramApi {
 		// Append scope if present
 		if (config.hasScope()) {
 			return String.format(Constants.SCOPED_AUTHORIZE_URL, config.getApiKey(),
-					formURLEncode(config.getCallback()), formURLEncode(config.getScope()));
+					formURLEncode(config.getCallback()), config.getScope());
 		} else {
 			return String.format(Constants.AUTHORIZE_URL, config.getApiKey(), formURLEncode(config.getCallback()));
 		}

--- a/src/test/java/org/jinstagram/auth/InstagramApiTest.java
+++ b/src/test/java/org/jinstagram/auth/InstagramApiTest.java
@@ -119,5 +119,20 @@ public class InstagramApiTest {
 		String result = fixture.getAuthorizationUrl(config);
 		assertNotNull(result);
 	}
+	
+	/**
+	 * Run the String getAuthorizationUrl(OAuthConfig) method test.
+	 *
+	 * @throws Exception
+	 *
+	 * 
+	 */
+	@Test
+	public void testGetAuthorizationUrlWithScope() throws Exception {
+		InstagramApi fixture = new InstagramApi();
+		OAuthConfig config = new OAuthConfig("dc5cb05605435cf4abaa5a1f17b7d457", "4c587a5ff4565989907177c11fda9999", "http://localhost", "likes+comments");
+		String result = fixture.getAuthorizationUrl(config);
+		assertEquals("https://api.instagram.com/oauth/authorize/?client_id=dc5cb05605435cf4abaa5a1f17b7d457&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=likes+comments",result);
+	}
 
 }


### PR DESCRIPTION
Econde on instagram should be something like this "likes+comments" and formURLEncoded broke it.