### PR TITLE
deprecate TagMediaFeed and the API using it

### DIFF
--- a/src/main/java/org/jinstagram/InstagramBase.java
+++ b/src/main/java/org/jinstagram/InstagramBase.java
@@ -570,13 +570,29 @@ public abstract class InstagramBase implements InstagramClient {
         return getRecentMediaTags(tagName, 0);
     }
 
-    /* (non-Javadoc)
-     * @see org.jinstagram.InstagramClient#getRecentMediaTags(java.lang.String, long)
-     */
+	/* (non-Javadoc)
+	 * @see org.jinstagram.InstagramClient#getRecentMediaFeedTags(java.lang.String)
+	 */
+	@Override
+	public MediaFeed getRecentMediaFeedTags(String tagName) throws InstagramException {
+		return getRecentMediaFeedTags(tagName, 0);
+	}
+
+	/* (non-Javadoc)
+		 * @see org.jinstagram.InstagramClient#getRecentMediaTags(java.lang.String, long)
+		 */
     @Override
     public TagMediaFeed getRecentMediaTags(String tagName, long count) throws InstagramException {
         return getRecentMediaTags(tagName, null, null, count);
     }
+
+	/* (non-Javadoc)
+	 * @see org.jinstagram.InstagramClient#getRecentMediaFeedTags(java.lang.String, long)
+	 */
+	@Override
+	public MediaFeed getRecentMediaFeedTags(String tagName, long count) throws InstagramException {
+		return getRecentMediaFeedTags(tagName, null, null, count);
+	}
 
     /* (non-Javadoc)
      * @see org.jinstagram.InstagramClient#getRecentMediaTags(java.lang.String, java.lang.String, java.lang.String)
@@ -585,6 +601,14 @@ public abstract class InstagramBase implements InstagramClient {
     public TagMediaFeed getRecentMediaTags(String tagName, String minTagId, String maxTagId) throws InstagramException {
         return getRecentMediaTags(tagName, minTagId, maxTagId, 0);
     }
+
+	/* (non-Javadoc)
+	 * @see org.jinstagram.InstagramClient#getRecentMediaFeedTags(java.lang.String, java.lang.String, java.lang.String)
+	 */
+	@Override
+	public MediaFeed getRecentMediaFeedTags(String tagName, String minTagId, String maxTagId) throws InstagramException {
+		return getRecentMediaFeedTags(tagName, minTagId, maxTagId, 0);
+	}
 
     /* (non-Javadoc)
      * @see org.jinstagram.InstagramClient#getRecentMediaTags(java.lang.String, java.lang.String, java.lang.String, long)
@@ -610,6 +634,30 @@ public abstract class InstagramBase implements InstagramClient {
         return createInstagramObject(Verbs.GET, TagMediaFeed.class, apiMethod, rawApiMethod, params);
     }
 
+	/* (non-Javadoc)
+	 * @see org.jinstagram.InstagramClient#getRecentMediaFeedTags(java.lang.String, java.lang.String, java.lang.String, long)
+	 */
+	@Override
+	public MediaFeed getRecentMediaFeedTags(String tagName, String minTagId, String maxTagId, long count)
+			throws InstagramException {
+		Map<String, String> params = new HashMap<String, String>();
+
+		if (!StringUtils.isEmpty(minTagId))
+			params.put(QueryParam.MIN_TAG_ID, String.valueOf(minTagId));
+
+		if (!StringUtils.isEmpty(maxTagId))
+			params.put(QueryParam.MAX_TAG_ID, String.valueOf(maxTagId));
+
+		if (count != 0) {
+			params.put(QueryParam.COUNT, String.valueOf(count));
+		}
+
+		String apiMethod = String.format(Methods.TAGS_RECENT_MEDIA, URLUtils.encodeURIComponent(tagName));
+		String rawApiMethod = String.format(Methods.TAGS_RECENT_MEDIA, tagName);
+
+		return createInstagramObject(Verbs.GET, MediaFeed.class, apiMethod, rawApiMethod, params);
+	}
+
     /* (non-Javadoc)
      * @see org.jinstagram.InstagramClient#getRecentMediaTagsByRegularIds(java.lang.String, java.lang.String, java.lang.String)
      */
@@ -629,6 +677,25 @@ public abstract class InstagramBase implements InstagramClient {
         String rawApiMethod = String.format(Methods.TAGS_RECENT_MEDIA, tagName);
         return createInstagramObject(Verbs.GET, TagMediaFeed.class, apiMethod, rawApiMethod, params);
     }
+
+	/* (non-Javadoc)
+	 * @see org.jinstagram.InstagramClient#getRecentMediaFeedTagsByRegularIds(java.lang.String, java.lang.String, java.lang.String)
+	 */
+	@Override
+	public MediaFeed getRecentMediaFeedTagsByRegularIds(String tagName, String minId, String maxId)
+			throws InstagramException {
+		Map<String, String> params = new HashMap<String, String>();
+
+		if (!StringUtils.isEmpty(minId))
+			params.put(QueryParam.MIN_ID, String.valueOf(minId));
+
+		if (!StringUtils.isEmpty(maxId))
+			params.put(QueryParam.MAX_ID, String.valueOf(maxId));
+
+		String apiMethod = String.format(Methods.TAGS_RECENT_MEDIA, URLUtils.encodeURIComponent(tagName));
+		String rawApiMethod = String.format(Methods.TAGS_RECENT_MEDIA, tagName);
+		return createInstagramObject(Verbs.GET, MediaFeed.class, apiMethod, rawApiMethod, params);
+	}
 
     /* (non-Javadoc)
      * @see org.jinstagram.InstagramClient#searchTags(java.lang.String)

--- a/src/main/java/org/jinstagram/InstagramClient.java
+++ b/src/main/java/org/jinstagram/InstagramClient.java
@@ -57,6 +57,7 @@ public interface InstagramClient {
      *
      *             use getUserRecentMedia() instead
      */
+    @Deprecated
     MediaFeed getUserFeeds() throws InstagramException;
 
     /**
@@ -101,6 +102,7 @@ public interface InstagramClient {
      *             use getUserRecentMedia(int count, String minId, String maxId)
      *             instead
      */
+    @Deprecated
     MediaFeed getUserFeeds(String maxId, String minId, long count)
             throws InstagramException;
 
@@ -157,7 +159,10 @@ public interface InstagramClient {
      * 
      * @param pagination
      * @throws InstagramException
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaNextPage(Pagination)}. In the
+     * next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getTagMediaInfoNextPage(Pagination pagination)
             throws InstagramException;
 
@@ -376,6 +381,7 @@ public interface InstagramClient {
      *
      *             No analog method was offered instead.
      */
+    @Deprecated
     MediaFeed getPopularMedia() throws InstagramException;
 
     /**
@@ -472,8 +478,23 @@ public interface InstagramClient {
      * @return a TagMediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaFeedTags(String)}. In the
+     * next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getRecentMediaTags(String tagName) throws InstagramException;
+
+	/**
+	 * Get a list of recently tagged media.
+	 *
+	 * @param tagName {@link String}
+	 *             the name of the tag
+	 * @return {@link MediaFeed}
+	 *             the media feed for the first page
+	 * @throws InstagramException
+	 *             if any error occurs.
+	 */
+	MediaFeed getRecentMediaFeedTags(String tagName) throws InstagramException;
 
     /**
      * Get a list of recently tagged media.
@@ -485,10 +506,27 @@ public interface InstagramClient {
      * @return a TagMediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaFeedTags(String, long)}. In the
+     * next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getRecentMediaTags(String tagName, long count)
             throws InstagramException;
 
+	/**
+	 * Get at most <em>count</em> number of recently tagged media.
+	 *
+	 * @param tagName {@link String}
+	 *             the name of the tag
+	 * @param count {@code int}
+	 *             set to 0 to use default
+	 * @return {@link MediaFeed}
+	 *             the media feed for the first page
+	 * @throws InstagramException
+	 *             if any error occurs.
+	 */
+	MediaFeed getRecentMediaFeedTags(String tagName, long count) throws InstagramException;
+
     /**
      * Get a list of recently tagged media.
      *
@@ -501,9 +539,29 @@ public interface InstagramClient {
      * @return a TagMediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaFeedTags(String, String, String)}. In the
+     * next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getRecentMediaTags(String tagName, String minTagId,
             String maxTagId) throws InstagramException;
+
+	/**
+	 * Get a list of recently tagged media.
+	 *
+	 * @param tagName
+	 *            name of the tag.
+	 * @param minTagId
+	 *            (return media before this tag_id), can be null
+	 * @param maxTagId
+	 *            (return media before this tag_id), can be null
+	 * @return {@link MediaFeed}
+	 *             the media feed for the first page
+	 * @throws InstagramException
+	 *             if any error occurs.
+	 */
+	MediaFeed getRecentMediaFeedTags(String tagName, String minTagId, String maxTagId)
+			throws InstagramException;
 
     /**
      * Get a list of recently tagged media.
@@ -519,9 +577,31 @@ public interface InstagramClient {
      * @return a TagMediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaFeedTags(String, String, String, long)}. In the
+     * next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getRecentMediaTags(String tagName, String minTagId,
             String maxTagId, long count) throws InstagramException;
+
+	/**
+	 * Get a list of recently tagged media.
+	 *
+	 * @param tagName
+	 *            name of the tag.
+	 * @param minTagId
+	 *            (return media before this tag_id), can be null
+	 * @param maxTagId
+	 *            (return media before this tag_id), can be null
+	 * @param count,
+	 *            set to 0 to use default
+	 * @return {@link MediaFeed}
+	 *             the media feed for the first page
+	 * @throws InstagramException
+	 *             if any error occurs.
+	 */
+	MediaFeed getRecentMediaFeedTags(String tagName, String minTagId, String maxTagId, long count)
+			throws InstagramException;
 
     /**
      * Get a list of recently tagged media.
@@ -531,9 +611,25 @@ public interface InstagramClient {
      * @return a TagMediaFeed object.
      * @throws InstagramException
      *             if any error occurs.
+     * @deprecated This API is deprecated in favor {@link #getRecentMediaFeedTagsByRegularIds(String, String, String)}.
+     * In the next major version release ({@code 2.0}), both {@link TagMediaFeed} and this API will be removed.
      */
+    @Deprecated
     TagMediaFeed getRecentMediaTagsByRegularIds(String tagName, String minId,
             String maxId) throws InstagramException;
+
+	/**
+	 * Get a list of recently tagged media.
+	 *
+	 * @param tagName
+	 *            name of the tag.
+	 * @return {@link MediaFeed}
+	 *             the media feed for the first page
+	 * @throws InstagramException
+	 *             if any error occurs.
+	 */
+	MediaFeed getRecentMediaFeedTagsByRegularIds(String tagName, String minId, String maxId)
+			throws InstagramException;
 
     /**
      * Search for tags by name - results are ordered first as an exact match,

--- a/src/main/java/org/jinstagram/entity/tags/TagMediaFeed.java
+++ b/src/main/java/org/jinstagram/entity/tags/TagMediaFeed.java
@@ -6,9 +6,16 @@ import org.jinstagram.InstagramObject;
 import org.jinstagram.entity.common.Meta;
 import org.jinstagram.entity.common.Pagination;
 import org.jinstagram.entity.users.feed.MediaFeedData;
+import org.jinstagram.entity.users.feed.MediaFeed;
 
 import java.util.List;
 
+/**
+ * @deprecated This model is deprecated in favor of {@link MediaFeed}. {@link MediaFeed}
+ * generalizes the media returned for both users and tags. In the next major version release
+ * ({@code 2.0}), {@link TagMediaFeed} will be removed.
+ */
+@Deprecated
 public class TagMediaFeed extends InstagramObject{
 	@SerializedName("data")
 	private List<MediaFeedData> data;


### PR DESCRIPTION
*Motivation*

TagMediaFeed encapsulates exactly the same state as MediaFeed. Having
two separate classes makes it difficult to:
- reason about
- process a collection of both MediaFeed and TagMediaFeed

Point #2 is exacerbated by the returned MediaFeed type from the
InstagramClient#getRecentMediaNextPage API. This API flow starts with
an initial TagMediaFeed and fetches subsequence MediaFeed objects
which makes using Java 8 streams difficult.

*Solution*

Deprecate the use of TagMediaFeed in favor of MediaFeed. APIs were
added to InstagramClient to fetch tagged media with a MediaFeed
response type.

Deprecation notices were added conveying API removal in next major
version (likely 2) and what APIs you should use now to avoid
deprecation warnings.

fixes #179