### PR TITLE
removed logger impl deps from compile/runtime cp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j-api.version>1.7.21</slf4j-api.version>
-        <log4j.version>2.7</log4j.version>
         <junit.version>4.12</junit.version>
         <gson.version>2.7</gson.version>
         <commons.lang3.version>3.4</commons.lang3.version>
         <commons.codec.version>1.10</commons.codec.version>
+        <logback.version>1.1.7</logback.version>
         <mockito.core.version>2.2.0</mockito.core.version>
         <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
         <maven-compiler-plugin.java.source.version>1.6</maven-compiler-plugin.java.source.version>
@@ -51,68 +51,50 @@
     </scm>
 
     <dependencies>
+        <!-- compile dependencies -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
         </dependency>
-
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>${commons.codec.version}</version>
         </dependency>
 
-        <!-- logging -->
+        <!-- logging, api only -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j-api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
 
+        <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
 
     <distributionManagement>
         <snapshotRepository>
@@ -121,9 +103,7 @@
         </snapshotRepository>
     </distributionManagement>
 
-
     <build>
-
         <plugins>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
@@ -168,7 +148,6 @@
                     <repoToken>${coveralls_repo_token}</repoToken>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
Motivation

Including logger implementations within a library can cause logging
issues when including in an application. Usually an application will
have specific logging needs and will provide the slf4j log
implementation.

Solution

This change removes log4j dependencies from the compile/runtime
classpath of jInstagram. Only the slf4j API is included.

Additionally logback-classic (slf4j logger impl) is added on the
test classpath for test log debugging.